### PR TITLE
Fixed issue #19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unused `setPendingText()`, `copyPending()`, and `_pendingText` from clipboard.mu (Fixed issue #18).
 - Session save failure now indicated in final feedback when Save Review partially fails (Fixed issue #11).
 - Removed empty `requires` field from PACKAGE manifest (Fixed issue #15).
+- Removed unreachable return in `normalize_note()` (Fixed issue #19).
 
 ## [1.5.0] - 2026-01-29
 

--- a/NotesOverlay.py
+++ b/NotesOverlay.py
@@ -1527,8 +1527,6 @@ class NotesOverlayMode(MinorMode):
             else:
                 return f"- {content_after_dash}"
 
-        return unwrapped
-
     def format_notes_for_export(self, source_name, source_path, frame_notes, drawing_only_frames=None,
                                 frames_folder=None, session_path=None):
         """


### PR DESCRIPTION
## Summary

Removed unreachable `return unwrapped` statement in `normalize_note()`. All prior branches (empty, no dash, dash-only, dash-with-space, else) already return, so the final return was dead code.

## Changes

- Removed line 1530: `return unwrapped` in `normalize_note()`
- Updated CHANGELOG.md

Fixes #19

## How to verify

1. Open RV with SnapReview loaded.
2. Add notes to frames and run **Copy Notes** or **Save Review**.
3. Confirm notes export and paste correctly. No behavior change; dead code removed.